### PR TITLE
Add service card visuals and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,30 +59,55 @@
 
   <!-- Servicios -->
   <section id="servicios" class="services container">
-    <h2>Servicios</h2>
-    <div class="services-grid">
-      <div class="service-card">
-        <h4>Consultoría</h4>
-        <p>Asesoría experta para elegir tu sistema</p>
+      <h2>Servicios</h2>
+      <div class="services-grid">
+        <div class="service-card">
+          <div class="service-image">
+            <img src="assets/homeconsultoria.webp" alt="Consultoría">
+            <button class="service-btn">Solicitar servicio</button>
+          </div>
+          <h4>Consultoría</h4>
+          <p>Asesoría experta para elegir tu sistema</p>
+          <a href="#" class="service-link">Ver más</a>
+        </div>
+        <div class="service-card">
+          <div class="service-image">
+            <img src="assets/homeinstalacion.webp" alt="Instalación">
+            <button class="service-btn">Solicitar servicio</button>
+          </div>
+          <h4>Instalación</h4>
+          <p>Instalación profesional y garantizada</p>
+          <a href="#" class="service-link">Ver más</a>
+        </div>
+        <div class="service-card">
+          <div class="service-image">
+            <img src="assets/homemantenimineto.webp" alt="Mantenimiento">
+            <button class="service-btn">Solicitar servicio</button>
+          </div>
+          <h4>Mantenimiento</h4>
+          <p>Planes preventivos y correctivos</p>
+          <a href="#" class="service-link">Ver más</a>
+        </div>
+        <div class="service-card">
+          <div class="service-image">
+            <img src="assets/homereparacion.webp" alt="Reparación">
+            <button class="service-btn">Solicitar servicio</button>
+          </div>
+          <h4>Reparación</h4>
+          <p>Diagnóstico y solución rápida</p>
+          <a href="#" class="service-link">Ver más</a>
+        </div>
+        <div class="service-card">
+          <div class="service-image">
+            <img src="assets/homereemplazo.webp" alt="Reemplazo">
+            <button class="service-btn">Solicitar servicio</button>
+          </div>
+          <h4>Reemplazo</h4>
+          <p>Actualización a equipos más eficientes</p>
+          <a href="#" class="service-link">Ver más</a>
+        </div>
       </div>
-      <div class="service-card">
-        <h4>Instalación</h4>
-        <p>Instalación profesional y garantizada</p>
-      </div>
-      <div class="service-card">
-        <h4>Mantenimiento</h4>
-        <p>Planes preventivos y correctivos</p>
-      </div>
-      <div class="service-card">
-        <h4>Reparación</h4>
-        <p>Diagnóstico y solución rápida</p>
-      </div>
-      <div class="service-card">
-        <h4>Reemplazo</h4>
-        <p>Actualización a equipos más eficientes</p>
-      </div>
-    </div>
-  </section>
+    </section>
 
   <!-- Casos de Éxito -->
   <section id="casos" class="cases">

--- a/style.css
+++ b/style.css
@@ -184,15 +184,56 @@ body {
 
 .services-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 20px;
 }
 
 .service-card {
   background: #fff;
-  padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.service-image {
+  position: relative;
+}
+
+.service-image img {
+  width: 100%;
+  display: block;
+}
+
+.service-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: #5C8AC6;
+  color: #fff;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.service-card h4 {
+  margin: 15px 20px 5px;
+  color: #235183;
+}
+
+.service-card p {
+  margin: 0 20px 10px;
+  flex-grow: 1;
+}
+
+.service-link {
+  margin: 0 20px 20px;
+  color: #235183;
+  text-decoration: none;
+  font-weight: 500;
 }
 
 /* ==============================


### PR DESCRIPTION
## Summary
- Add images, buttons, and "Ver más" links to each service card
- Replace services CSS block with responsive card styling

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fcdb1a348333b8cb62a48e742d49